### PR TITLE
Resolve chart bugs hk

### DIFF
--- a/report_embeds/chart_functions.R
+++ b/report_embeds/chart_functions.R
@@ -58,7 +58,7 @@ cc_theme <- hc_theme(
       fontFamily = main_font, # font_title
       fontWeight = black_font_weight,
       textAlign="left",
-      fontSize='4.55vmin'
+      fontSize='4.5vmin'
     )
   ),
   subtitle = list(

--- a/report_embeds/chart_functions.R
+++ b/report_embeds/chart_functions.R
@@ -58,7 +58,7 @@ cc_theme <- hc_theme(
       fontFamily = main_font, # font_title
       fontWeight = black_font_weight,
       textAlign="left",
-      fontSize='4vmin'
+      fontSize='4.55vmin'
     )
   ),
   subtitle = list(
@@ -66,7 +66,7 @@ cc_theme <- hc_theme(
       color = meteorite, 
       fontFamily = main_font, # font_subtitle
       fontWeight = regular_font_weight,
-      fontSize='2vmin'
+      fontSize='3vmin'
     )
   ),
   caption = list(
@@ -75,7 +75,7 @@ cc_theme <- hc_theme(
       fontFamily = main_font, # font_caption
       fontWeight = regular_font_weight,
       textAlign = "left",
-      fontSize = "1vmin"
+      fontSize = "1.5vmin"
     ),
     useHTML = TRUE
   ),
@@ -84,7 +84,7 @@ cc_theme <- hc_theme(
       color = gainsboro,
       fontFamily = main_font, # font_axis_label
       fontWeight = semi_bold_font_weight,
-      fontSize="1.5vmin"
+      fontSize="3vmin"
     )
   ),
   
@@ -96,7 +96,7 @@ cc_theme <- hc_theme(
         fontWeight = semi_bold_font_weight,
         width=120,  #argument to modify the width of the labels,
         # spacingLeft = "150px",
-        fontSize="1.5vmin")),
+        fontSize="3vmin")),
     lineColor=gainsboro
   ),
   
@@ -106,7 +106,7 @@ cc_theme <- hc_theme(
         color=black,
         fontFamily = main_font, # font_axis_label
         fontWeight = regular_font_weight,
-        fontSize="1.5vmin",
+        fontSize="3min",
         margin = 50)),
     gridLineWidth=0, # removes vertical grid lines
     visible=TRUE, # makes axis line visible
@@ -119,7 +119,7 @@ cc_theme <- hc_theme(
       fontFamily = main_font, # font_axis_label
       fontWeight = regular_font_weight,
       color = black,
-      fontSize = '1.5vmin'
+      fontSize = '3vmin'
     ),
     
     itemHoverStyle = list(


### PR DESCRIPTION
For some reason vmin units display differently on the maps and data page relative to our individual embed pages. Potentially because they are inside of a container on the maps and data page but are not on the individual embed pages.

Increased font size to overcome the smaller fonts on maps and data page.